### PR TITLE
Investigate hall of fame logo discrepancy

### DIFF
--- a/public/data/team-mappings.json
+++ b/public/data/team-mappings.json
@@ -72,7 +72,7 @@
   "Marq": { "id": "269", "name": "Marquette", "logo": "/logos/teams/269.png" },
   "Wisc": { "id": "275", "name": "Wisconsin", "logo": "/logos/teams/275.png" },
   "WV": { "id": "277", "name": "West Virginia", "logo": "/logos/teams/277.png" },
-  "Lou": { "id": "309", "name": "Louisville", "logo": "/logos/teams/309.png" },
+  "Lou": { "id": "309", "name": "Louisiana", "logo": "/logos/teams/309.png" },
   "Iona": { "id": "314", "name": "Iona", "logo": "/logos/teams/314.png" },
   "CleSt": { "id": "325", "name": "Cleveland State", "logo": "/logos/teams/325.png" },
   "USt": { "id": "328", "name": "Utah State", "logo": "/logos/teams/328.png" },
@@ -165,5 +165,5 @@
   "Troy": { "id": "2653", "name": "Troy", "logo": "/logos/teams/2653.png" },
   "Wof": { "id": "2747", "name": "Wofford", "logo": "/logos/teams/2747.png" },
   "Bry": { "id": "2803", "name": "Bryant", "logo": "/logos/teams/2803.png" },
-  "UL": { "id": "97", "name": "Louisiana", "logo": "/logos/teams/97.png" }
+  "UL": { "id": "97", "name": "Louisville", "logo": "/logos/teams/97.png" }
 }


### PR DESCRIPTION
Corrected team name mappings in `team-mappings.json` to fix Louisville's logo displaying incorrectly.

The `UL` abbreviation (ID 97) was incorrectly mapped to "Louisiana", and `Lou` (ID 309) was incorrectly mapped to "Louisville". This PR swaps these mappings so that ID 97 correctly corresponds to "Louisville" and ID 309 to "Louisiana".

---
<a href="https://cursor.com/background-agent?bcId=bc-634be318-57d2-4d8c-82c9-3107642033ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-634be318-57d2-4d8c-82c9-3107642033ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

